### PR TITLE
Fix failover stops at first error

### DIFF
--- a/dyndns/external.go
+++ b/dyndns/external.go
@@ -83,7 +83,7 @@ func GetExternalIPv6() (string, error) {
 			log.Logger.Printf("Bad address received from IPv6 address provider %v: %v", url, err)
 			continue
 		} else {
-			return "", err
+			return resp, nil
 		}
 	}
 

--- a/dyndns/external_test.go
+++ b/dyndns/external_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/razoralpha/name-dyndns/log"
 )
 
 func testServerHandler(w http.ResponseWriter, r *http.Request) {
@@ -46,4 +49,9 @@ func TestGetExternalIPFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Should have returned error when no service can be reached")
 	}
+}
+
+func TestMain(m *testing.M) {
+	log.Init(os.Stdout)
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Hi there, here is another change for you to consider.

It seems at some point a regression was introduced where the external IP acquisition will stop on the first failure and not continue. This also seems to have caused the tests to fail. This change allows the failover to continue and also adds some logging if a failure occurs.